### PR TITLE
Converting CSS Framework to Material 2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@angular/core": "^5.1.0",
     "@angular/forms": "^5.1.0",
     "@angular/http": "^5.1.0",
+    "@angular/material": "5.2.3",
     "@angular/platform-browser": "^5.1.0",
     "@angular/platform-browser-dynamic": "^5.1.0",
     "@angular/router": "^5.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "@angular/common": "^5.1.0",
     "@angular/compiler": "^5.1.0",
     "@angular/core": "^5.1.0",
+    "@angular/flex-layout": "5.0.0-beta.13",
     "@angular/forms": "^5.1.0",
     "@angular/http": "^5.1.0",
     "@angular/material": "5.2.3",

--- a/client/package.json
+++ b/client/package.json
@@ -33,7 +33,7 @@
     "zone.js": "^0.8.14"
   },
   "devDependencies": {
-    "@angular/cli": "1.5.0",
+    "@angular/cli": "^1.5.0",
     "@angular/compiler-cli": "^5.1.0",
     "@angular/language-service": "^5.1.0",
     "@types/jasmine": "~2.5.53",

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -6,7 +6,7 @@ import {HttpClientModule} from '@angular/common/http';
 import {RouterModule} from '@angular/router';
 
 import {FlexLayoutModule} from '@angular/flex-layout';
-import {MatChipsModule, MatTabsModule} from '@angular/material';
+import {MatCardModule, MatChipsModule, MatTabsModule} from '@angular/material';
 
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
@@ -103,6 +103,7 @@ export function tokenGetter(): string {
     NoopAnimationsModule,
     NgxDatatableModule,
     FlexLayoutModule,
+    MatCardModule,
     MatChipsModule,
     MatTabsModule
   ],

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -5,6 +5,7 @@ import {JwtModule} from '@auth0/angular-jwt';
 import {HttpClientModule} from '@angular/common/http';
 import {RouterModule} from '@angular/router';
 
+import {FlexLayoutModule} from '@angular/flex-layout';
 import {MatChipsModule} from '@angular/material';
 
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
@@ -101,6 +102,7 @@ export function tokenGetter(): string {
     ReactiveFormsModule,
     NoopAnimationsModule,
     NgxDatatableModule,
+    FlexLayoutModule,
     MatChipsModule
   ],
   providers: [IngestService, BrokerService, AuthService, FormBuilder, AlertService, LoaderService, FlattenService],

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -6,7 +6,7 @@ import {HttpClientModule} from '@angular/common/http';
 import {RouterModule} from '@angular/router';
 
 import {FlexLayoutModule} from '@angular/flex-layout';
-import {MatChipsModule} from '@angular/material';
+import {MatChipsModule, MatTabsModule} from '@angular/material';
 
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
@@ -103,7 +103,8 @@ export function tokenGetter(): string {
     NoopAnimationsModule,
     NgxDatatableModule,
     FlexLayoutModule,
-    MatChipsModule
+    MatChipsModule,
+    MatTabsModule
   ],
   providers: [IngestService, BrokerService, AuthService, FormBuilder, AlertService, LoaderService, FlattenService],
   bootstrap: [AppComponent]

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -5,6 +5,8 @@ import {JwtModule} from '@auth0/angular-jwt';
 import {HttpClientModule} from '@angular/common/http';
 import {RouterModule} from '@angular/router';
 
+import {MatChipsModule} from '@angular/material';
+
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
@@ -98,7 +100,8 @@ export function tokenGetter(): string {
     SharedModule,
     ReactiveFormsModule,
     NoopAnimationsModule,
-    NgxDatatableModule
+    NgxDatatableModule,
+    MatChipsModule
   ],
   providers: [IngestService, BrokerService, AuthService, FormBuilder, AlertService, LoaderService, FlattenService],
   bootstrap: [AppComponent]

--- a/client/src/app/submission/metadata-list/metadata-list.component.scss
+++ b/client/src/app/submission/metadata-list/metadata-list.component.scss
@@ -20,3 +20,9 @@
 datatable-body.datatable-body{
   height: 500px;
 }
+
+/* TODO revisit ViewEncapsulation.None on component, use :host-context instead  */
+app-metadata-list {
+  display: block;
+  margin-top: 24px;
+}

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -15,7 +15,7 @@ import {Subscription} from "rxjs/Subscription";
 @Component({
   selector: 'app-metadata-list',
   templateUrl: './metadata-list.component.html',
-  styleUrls: ['./metadata-list.component.css'],
+  styleUrls: ['./metadata-list.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
 

--- a/client/src/app/submission/metadata/metadata.component.css
+++ b/client/src/app/submission/metadata/metadata.component.css
@@ -1,9 +1,0 @@
-/*.card {*/
-  /*resize: both;*/
-  /*overflow: auto*/
-/*}*/
-
-/*.ngx-datatable {*/
-  /*resize: both;*/
-  /*overflow: auto*/
-/*}*/

--- a/client/src/app/submission/metadata/metadata.component.html
+++ b/client/src/app/submission/metadata/metadata.component.html
@@ -1,20 +1,18 @@
 <script src="../../shared/components/upload/upload.component.ts"></script>
 <app-upload [projectId]="projectId" *ngIf="!submissionEnvelopeId" ></app-upload>
-<div class="card" *ngIf="submissionEnvelopeId">
-  <div class="card-body">
-    <mat-tab-group>
-      <mat-tab label="Samples">
-        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'samples'"> </app-metadata-list>
-      </mat-tab>
-      <mat-tab label="Protocols">
-        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'protocols'"> </app-metadata-list>
-      </mat-tab>
-      <mat-tab label="Assays">
-        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'assays'"> </app-metadata-list>
-      </mat-tab>
-      <mat-tab label="Analyses">
-        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'analyses'"> </app-metadata-list>
-      </mat-tab>
-    </mat-tab-group>
-  </div>
-</div>
+<mat-card *ngIf="submissionEnvelopeId">
+  <mat-tab-group>
+    <mat-tab label="Samples">
+      <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'samples'"> </app-metadata-list>
+    </mat-tab>
+    <mat-tab label="Protocols">
+      <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'protocols'"> </app-metadata-list>
+    </mat-tab>
+    <mat-tab label="Assays">
+      <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'assays'"> </app-metadata-list>
+    </mat-tab>
+    <mat-tab label="Analyses">
+      <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'analyses'"> </app-metadata-list>
+    </mat-tab>
+  </mat-tab-group>
+</mat-card>

--- a/client/src/app/submission/metadata/metadata.component.html
+++ b/client/src/app/submission/metadata/metadata.component.html
@@ -1,26 +1,20 @@
 <script src="../../shared/components/upload/upload.component.ts"></script>
-<div class="container-fluid"><br/>
-  <br/>
-  <app-upload [projectId]="projectId" *ngIf="!submissionEnvelopeId" ></app-upload>
-  <br/>
-
-  <div class="card" *ngIf="submissionEnvelopeId">
-    <div class="card-body">
-      <tabs [navClass]="'nav-tabs'">
-        <tab tabTitle="Samples">
-          <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'samples'"> </app-metadata-list>
-        </tab>
-        <tab tabTitle="Protocols">
-          <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'protocols'"> </app-metadata-list>
-        </tab>
-        <tab tabTitle="Assays">
-          <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'assays'"> </app-metadata-list>
-        </tab>
-        <tab tabTitle="Analyses">
-          <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'analyses'"> </app-metadata-list>
-        </tab>
-      </tabs>
-    </div>
+<app-upload [projectId]="projectId" *ngIf="!submissionEnvelopeId" ></app-upload>
+<div class="card" *ngIf="submissionEnvelopeId">
+  <div class="card-body">
+    <tabs [navClass]="'nav-tabs'">
+      <tab tabTitle="Samples">
+        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'samples'"> </app-metadata-list>
+      </tab>
+      <tab tabTitle="Protocols">
+        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'protocols'"> </app-metadata-list>
+      </tab>
+      <tab tabTitle="Assays">
+        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'assays'"> </app-metadata-list>
+      </tab>
+      <tab tabTitle="Analyses">
+        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'analyses'"> </app-metadata-list>
+      </tab>
+    </tabs>
   </div>
-  <br/>
 </div>

--- a/client/src/app/submission/metadata/metadata.component.html
+++ b/client/src/app/submission/metadata/metadata.component.html
@@ -2,19 +2,19 @@
 <app-upload [projectId]="projectId" *ngIf="!submissionEnvelopeId" ></app-upload>
 <div class="card" *ngIf="submissionEnvelopeId">
   <div class="card-body">
-    <tabs [navClass]="'nav-tabs'">
-      <tab tabTitle="Samples">
+    <mat-tab-group>
+      <mat-tab label="Samples">
         <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'samples'"> </app-metadata-list>
-      </tab>
-      <tab tabTitle="Protocols">
+      </mat-tab>
+      <mat-tab label="Protocols">
         <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'protocols'"> </app-metadata-list>
-      </tab>
-      <tab tabTitle="Assays">
+      </mat-tab>
+      <mat-tab label="Assays">
         <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'assays'"> </app-metadata-list>
-      </tab>
-      <tab tabTitle="Analyses">
+      </mat-tab>
+      <mat-tab label="Analyses">
         <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'analyses'"> </app-metadata-list>
-      </tab>
-    </tabs>
+      </mat-tab>
+    </mat-tab-group>
   </div>
 </div>

--- a/client/src/app/submission/metadata/metadata.component.scss
+++ b/client/src/app/submission/metadata/metadata.component.scss
@@ -9,4 +9,7 @@
 :host-context(.mat-tab-body-content) {
   display: block;
   margin-top: 24px;
+  mat-card {
+    margin: 0 3px 4px; /* Add margin to card so that card box shadow is not clipped by overflow settings on parent tab */ 
+  }
 }

--- a/client/src/app/submission/metadata/metadata.component.scss
+++ b/client/src/app/submission/metadata/metadata.component.scss
@@ -1,0 +1,12 @@
+/**
+ * Human Cell Atlas - Ingest UI
+ * http://ui.ingest.dev.data.humancellatlas.org
+ *
+ * Styles specific to app metadata component.
+ */
+
+/* Add margin to top of component if contained inside a tab */
+:host-context(.mat-tab-body-content) {
+  display: block;
+  margin-top: 24px;
+}

--- a/client/src/app/submission/metadata/metadata.component.ts
+++ b/client/src/app/submission/metadata/metadata.component.ts
@@ -5,7 +5,7 @@ import {TimerObservable} from "rxjs/observable/TimerObservable";
 @Component({
   selector: 'app-metadata',
   templateUrl: './metadata.component.html',
-  styleUrls: ['./metadata.component.css']
+  styleUrls: ['./metadata.component.scss']
 })
 export class MetadataComponent implements OnInit {
   @Input() submissionEnvelopeId: number;

--- a/client/src/app/submission/submission.component.html
+++ b/client/src/app/submission/submission.component.html
@@ -1,57 +1,44 @@
 <script src="submission.component.ts"></script>
 <script src="../shared/components/project/project.component.ts"></script>
-<div class="container-fluid mat-typography">
-  <br/>
-  <div class="row">
-    <div class="col-lg-12">
-      <div class="d-flex justify-content-between">
-        <h1 class="mat-headline">Submission</h1>
-        <mat-chip-list selectable="false">
-          <mat-basic-chip [ngClass]="getSubmissionStateChipClassName(submissionState)">{{submissionState}}</mat-basic-chip>
-        </mat-chip-list>
-      </div>
-    </div>
+<div fxLayout="column" class="mat-typography">
+  <div fxLayout="row" fxLayoutAlign="space-between center">
+    <h1 class="mat-headline">Submission</h1>
+    <mat-chip-list selectable="false">
+      <mat-basic-chip [ngClass]="getSubmissionStateChipClassName(submissionState)">{{submissionState}}</mat-basic-chip>
+    </mat-chip-list>
   </div>
-  <br/>
+  <div>
   <h3 class="subheading-2">{{projectName}}</h3>
-  <br/>
-  <div class="row">
-    <div class="col-lg-12">
-      <tabs>
-       <tab [href]="'overview'" tabTitle="Overview"  [active]="activeTab == 'overview'" >
-         <app-overview [project]="project" [projectId]="projectId" [submissionEnvelopeId]="submissionEnvelopeId"></app-overview>
-       </tab>
-        <tab [href]="'metadata'" tabTitle="Metadata" [active]="activeTab == 'metadata'">
-          <app-metadata
-            [projectId]="projectId"
-            [submissionEnvelopeId]="submissionEnvelopeId"
-            [samples]="samples"
-            [assays]="assays"
-            [protocols]="protocols"
-            [analyses]="analyses"
-            >
-          </app-metadata>
-        </tab>
-        <tab [href]="'data'" tabTitle="Data" [active]="activeTab == 'data'" [disabled]="!submissionEnvelopeId">
-          <app-files
-            [submissionEnvelope]="submissionEnvelope"
-            [submissionEnvelopeId]="submissionEnvelopeId" >
-          </app-files>
-        </tab>
-
-        <tab [href]="'submit'" [disabled]="!isSubmittable" tabTitle="Submit" [active]="activeTab == 'submit'">
-          <app-submit
-            [submissionEnvelope$]="submissionEnvelope$"
-            [submitLink]="submitLink"
-            [isSubmitted]="isSubmitted"
-
-            [submissionEnvelopeId]="submissionEnvelopeId">
-
-          </app-submit>
-        </tab>
-      </tabs>
-
-    </div>
+  <tabs>
+    <tab [href]="'overview'" tabTitle="Overview"  [active]="activeTab == 'overview'" >
+      <app-overview [project]="project" [projectId]="projectId" [submissionEnvelopeId]="submissionEnvelopeId"></app-overview>
+    </tab>
+    <tab [href]="'metadata'" tabTitle="Metadata" [active]="activeTab == 'metadata'">
+      <app-metadata
+              [projectId]="projectId"
+              [submissionEnvelopeId]="submissionEnvelopeId"
+              [samples]="samples"
+              [assays]="assays"
+              [protocols]="protocols"
+              [analyses]="analyses"
+      >
+      </app-metadata>
+    </tab>
+    <tab [href]="'data'" tabTitle="Data" [active]="activeTab == 'data'" [disabled]="!submissionEnvelopeId">
+      <app-files
+              [submissionEnvelope]="submissionEnvelope"
+              [submissionEnvelopeId]="submissionEnvelopeId" >
+      </app-files>
+    </tab>
+    <tab [href]="'submit'" [disabled]="!isSubmittable" tabTitle="Submit" [active]="activeTab == 'submit'">
+      <app-submit
+              [submissionEnvelope$]="submissionEnvelope$"
+              [submitLink]="submitLink"
+              [isSubmitted]="isSubmitted"
+            
+              [submissionEnvelopeId]="submissionEnvelopeId">
+      </app-submit>
+    </tab>
+  </tabs>
   </div>
 </div>
-

--- a/client/src/app/submission/submission.component.html
+++ b/client/src/app/submission/submission.component.html
@@ -1,28 +1,19 @@
 <script src="submission.component.ts"></script>
 <script src="../shared/components/project/project.component.ts"></script>
-<div class="container-fluid">
+<div class="container-fluid mat-typography">
   <br/>
-
   <div class="row">
-    <div class="col-sm-10"><h1> Submission</h1></div>
-    <div class="col-sm-2">
-      <h3>
-        <span class="float-right" [ngSwitch]="submissionState">
-          <span *ngSwitchCase="'Pending'" class="badge badge-pill badge-warning">{{submissionState}}</span>
-          <span *ngSwitchCase="'Draft'" class="badge badge-pill badge-warning">{{submissionState}}</span>
-          <span *ngSwitchCase="'Validating'" class="badge badge-pill badge-info">{{submissionState}}</span>
-          <span *ngSwitchCase="'Valid'" class="badge badge-pill badge-success">{{submissionState}}</span>
-          <span *ngSwitchCase="'Invalid'" class="badge badge-pill badge-danger">{{submissionState}}</span>
-          <span *ngSwitchCase="'Submitted'" class="badge badge-pill badge-secondary">{{submissionState}}</span>
-          <span *ngSwitchCase="'Processing'" class="badge badge-pill border border-warning bg-light text-warning">{{submissionState}}</span>
-          <span *ngSwitchCase="'Cleanup'" class="badge badge-pill border border-warning bg-light text-warning">{{submissionState}}</span>
-          <span *ngSwitchCase="'Complete'" class="badge badge-pill border border-success bg-light text-success">{{submissionState}}</span>
-        </span>
-      </h3>
+    <div class="col-lg-12">
+      <div class="d-flex justify-content-between">
+        <h1 class="mat-headline">Submission</h1>
+        <mat-chip-list selectable="false">
+          <mat-basic-chip [ngClass]="getSubmissionStateChipClassName(submissionState)">{{submissionState}}</mat-basic-chip>
+        </mat-chip-list>
+      </div>
     </div>
   </div>
   <br/>
-  <h3>{{projectName}}</h3>
+  <h3 class="subheading-2">{{projectName}}</h3>
   <br/>
   <div class="row">
     <div class="col-lg-12">

--- a/client/src/app/submission/submission.component.html
+++ b/client/src/app/submission/submission.component.html
@@ -9,36 +9,39 @@
   </div>
   <div>
   <h3 class="subheading-2">{{projectName}}</h3>
-  <tabs>
-    <tab [href]="'overview'" tabTitle="Overview"  [active]="activeTab == 'overview'" >
-      <app-overview [project]="project" [projectId]="projectId" [submissionEnvelopeId]="submissionEnvelopeId"></app-overview>
-    </tab>
-    <tab [href]="'metadata'" tabTitle="Metadata" [active]="activeTab == 'metadata'">
-      <app-metadata
-              [projectId]="projectId"
-              [submissionEnvelopeId]="submissionEnvelopeId"
-              [samples]="samples"
-              [assays]="assays"
-              [protocols]="protocols"
-              [analyses]="analyses"
-      >
-      </app-metadata>
-    </tab>
-    <tab [href]="'data'" tabTitle="Data" [active]="activeTab == 'data'" [disabled]="!submissionEnvelopeId">
-      <app-files
-              [submissionEnvelope]="submissionEnvelope"
-              [submissionEnvelopeId]="submissionEnvelopeId" >
-      </app-files>
-    </tab>
-    <tab [href]="'submit'" [disabled]="!isSubmittable" tabTitle="Submit" [active]="activeTab == 'submit'">
-      <app-submit
-              [submissionEnvelope$]="submissionEnvelope$"
-              [submitLink]="submitLink"
-              [isSubmitted]="isSubmitted"
-            
-              [submissionEnvelopeId]="submissionEnvelopeId">
-      </app-submit>
-    </tab>
-  </tabs>
+    <mat-tab-group>
+      <mat-tab label="Overview">
+        <app-overview [project]="project" 
+                      [projectId]="projectId" 
+                      [submissionEnvelopeId]="submissionEnvelopeId">
+        </app-overview>
+      </mat-tab>
+      <mat-tab label="Metadata">
+        <app-metadata
+                [projectId]="projectId"
+                [submissionEnvelopeId]="submissionEnvelopeId"
+                [samples]="samples"
+                [assays]="assays"
+                [protocols]="protocols"
+                [analyses]="analyses"
+        >
+        </app-metadata>
+      </mat-tab>
+      <mat-tab label="Data" [disabled]="!submissionEnvelopeId">
+        <app-files
+                [submissionEnvelope]="submissionEnvelope"
+                [submissionEnvelopeId]="submissionEnvelopeId" >
+        </app-files>
+      </mat-tab>
+      <mat-tab label="Submit" [disabled]="!isSubmittable">
+        <app-submit
+                [submissionEnvelope$]="submissionEnvelope$"
+                [submitLink]="submitLink"
+                [isSubmitted]="isSubmitted"
+              
+                [submissionEnvelopeId]="submissionEnvelopeId">
+        </app-submit>
+      </mat-tab>
+    </mat-tab-group>
   </div>
 </div>

--- a/client/src/app/submission/submission.component.scss
+++ b/client/src/app/submission/submission.component.scss
@@ -15,7 +15,7 @@
   color: #ffffff;
   cursor: default;
   display: inline-flex;
-  transition: box-shadow 280ms cubic-bezier(.4,0,.2,1);
+  transition: box-shadow 280ms cubic-bezier(.4, 0, .2, 1);
   padding: 7px 12px;
   /* TODO applying BS naming convention for coloring chips, revisit once ingest-UI UI design is complete. Also revisit use of CSS variables. */
   &.danger {

--- a/client/src/app/submission/submission.component.scss
+++ b/client/src/app/submission/submission.component.scss
@@ -1,0 +1,44 @@
+/**
+ * Human Cell Atlas - Ingest UI
+ * http://ui.ingest.dev.data.humancellatlas.org
+ *
+ * Styles specific to submission component.
+ */
+
+/* 
+ * Mimic standard (non-basic) MD chip styles as a base for chips. Add additional classes to chips for styling of chips 
+ * in different states.
+ */
+.mat-basic-chip {
+  align-items: center;
+  border-radius: 24px;
+  color: #ffffff;
+  cursor: default;
+  display: inline-flex;
+  transition: box-shadow 280ms cubic-bezier(.4,0,.2,1);
+  padding: 7px 12px;
+  /* TODO applying BS naming convention for coloring chips, revisit once ingest-UI UI design is complete. Also revisit use of CSS variables. */
+  &.danger {
+    background-color: var(--danger);
+  }
+  &.info {
+    background-color: var(--info);
+  }
+  &.secondary {
+    background-color: var(--secondary);
+  }
+  &.success {
+    background-color: var(--success);
+  }
+  &.success-invert {
+    border: 1px solid var(--success);
+    color: var(--success);
+  }
+  &.warning {
+    background-color: var(--warning);
+  }
+  &.warning-invert {
+    border: 1px solid var(--warning);
+    color: var(--warning);
+  }
+}

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -10,7 +10,7 @@ import {FlattenService} from "../shared/services/flatten.service";
 @Component({
   selector: 'app-submission',
   templateUrl: './submission.component.html',
-  styleUrls: ['./submission.component.css']
+  styleUrls: ['./submission.component.scss']
 })
 export class SubmissionComponent implements OnInit {
   submissionEnvelopeId: string;
@@ -29,7 +29,7 @@ export class SubmissionComponent implements OnInit {
   activeTab: string;
 
   isSubmittable: boolean;
-  isSubmitted:boolean;
+  isSubmitted: boolean;
   submitLink: string;
 
   project: any;
@@ -37,7 +37,7 @@ export class SubmissionComponent implements OnInit {
   projectName: string;
 
   private alive: boolean;
-  private pollInterval : number;
+  private pollInterval: number;
 
   constructor(private ingestService: IngestService,
               private route: ActivatedRoute,
@@ -130,4 +130,43 @@ export class SubmissionComponent implements OnInit {
     return links && links['submit']? links['submit']['href'] : null;
   }
 
+  /**
+   * Return the CSS class name corresponding to the current submission state value, for styling the submission state
+   * chip.
+   *
+   * @param submissionState {string}
+   * @returns {string}
+   */
+  getSubmissionStateChipClassName(submissionState: string): string {
+
+    if ( submissionState === 'Pending' || submissionState === 'Draft' ) {
+      return 'warning';
+    }
+
+    if ( submissionState === 'Valid' ) {
+      return 'success';
+    }
+
+    if ( submissionState === 'Validating' ) {
+      return 'info';
+    }
+
+    if ( submissionState === 'Invalid' ) {
+      return 'danger';
+    }
+
+    if ( submissionState === 'Submitted' ) {
+      return 'secondary';
+    }
+
+    if ( submissionState === 'Processing' || submissionState === 'Cleanup' ) {
+      return 'warning-invert';
+    }
+
+    if ( submissionState === 'Complete' ) {
+      return 'success-invert';
+    }
+
+    return '';
+  }
 }

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -9,6 +9,7 @@
   <title>HCA Data Ingest</title>
   <base href="/">
   <script src="https://cdn.auth0.com/js/auth0/8.10.1/auth0.min.js"></script>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
   <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.2/css/bootstrap.min.css"-->
         <!--integrity="sha384-PsH8R72JQ3SOdhVi3uxftmaW6Vc51MKb0q5P2rRUpPvrszuE4W1povHYgTpBfshb" crossorigin="anonymous">-->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.2/flatly/bootstrap.min.css" >

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -9,3 +9,6 @@ body {
 @import '~@swimlane/ngx-datatable/release/index.css';
 @import '~@swimlane/ngx-datatable/release/themes/material.css';
 @import '~@swimlane/ngx-datatable/release/assets/icons.css';
+
+// Default MD theme TODO revisit - customize once ingest-ui UI design is completed 
+@import '~@angular/material/prebuilt-themes/deeppurple-amber.css';


### PR DESCRIPTION
# Updates

1. Upgraded `@angular/cli` to 1.7.1 due to error (see [https://github.com/angular/angular-cli/issues/9307](https://github.com/angular/angular-cli/issues/9307)).

1. Added `@angular/material` with `npm install @angular/material --save --save-exact`.

1. Added link to externally-hosted Roboto fonts in `index.html`. (Roboto is Material Design’s default font.) We can host the font files locally rather than requesting fonts over the wire, if that is preferred. 

1. Added `mat-typography` CSS class to `submission.component.html`, which applies default Material Design styles to all descendant tags. We can move this class to an ancestor element once we start to skin additional components. See [https://material.angular.io/guide/typography#usage](https://material.angular.io/guide/typography#usage) for details.

1. Updated Bootstrap `col-x` classes to be `col-xs` (rather than `col-lg` and `col-sm`) as Bootstrap `col-x` classes are mobile first. 

1. Added Material Design classes to `h1` and `h3` tags. See [https://material.angular.io/guide/typography#what-is-typography-](https://material.angular.io/guide/typography#what-is-typography-) for details.

1. Converted submission state display from Bootstrap badge to Material Design chip.

1. Installed `@angular/flex-layout` with `npm install --save --save-exact @angular/flex-layout@latest`.

1. Updated submission metadata tab-related components to use `flex-layout`.

1. Updated submission metadata tab-related components to use Material tabs. There is a defect with nested tabs where the selected tab UI is not displayed correctly (see [https://github.com/angular/material2/issues/687](https://github.com/angular/material2/issues/687)). I have not implemented the suggested workaround. I have also left the top-level tabs with their out-of-the-box styling rather than updating them to match the pill-like styles in existing ingest-UI.

1. Updated metadata component to use Material cards.

# To Discuss/Questions

1. Versioning in `package.json`. 

1. TS imports in `submission.component.html`.

1. Multiple nested `container-fluid` without corresponding `row` or `col-x` dependents.

1. Use of `<a href="javascript:void(0)" (click)="foo()"...>`.

1. `encapsulation: ViewEncapsulation.None` on `metadata-list.component.ts`.

# To Do

- [x] Convert grid from Bootstrap to Material.

- [x] Convert tabs from Bootstrap to Material.

- [x] Convert card from Bootstrap to Material.

- [ ] Convert metadata table from ngx-datatable to Material.